### PR TITLE
Add Nix shell file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for specific details about how to 
 
 This section will walk you through how to set up a development environment to work on the website locally.
 
+### Nix
+
+If you are using [Nix](https://nixos.org/), you can run `nix-shell` to enter an ephemeral shell with nodejs and yarn installed. It does not provide an editor.
+
 ### Editor
 
 This was originally written using VSCode, but any text editor will suffice, providing it has support for the required plugins (ESLint and Prettier)

--- a/shell.nix
+++ b/shell.nix
@@ -5,4 +5,7 @@ pkgs.mkShell {
       pkgs.nodejs
       pkgs.nodePackages.yarn
     ];
+    shellHooks = ''
+      yarn install
+      '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = [ 
+      pkgs.nodejs
+      pkgs.nodePackages.yarn
+    ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
-  pkgs.mkShell {
+pkgs.mkShell {
+    name = "cybersoc.co.uk";
     nativeBuildInputs = [ 
       pkgs.nodejs
       pkgs.nodePackages.yarn


### PR DESCRIPTION
`shell.nix` allows users of the nix package manager to install build tools (such as yarn, node, etc) ephemerally, rather than having to install them globally.

The old method still works, this merely provides an alternative.