### PR TITLE
Add tag functionality to blog posts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,11 @@
 {
-    "printWidth": 100,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": false,
-    "trailingComma": "all",
-    "bracketSpacing": true,
-    "jsxBracketSameLine": true,
-    "arrowParens": "always"
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "bracketSameLine": true,
+  "arrowParens": "always"
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef */
-// const { create } = require("domain");
 const path = require("path");
 
 const kebabCase = require("lodash/kebabCase");

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+import TextLink from "@components/TextLink";
+
+import { color } from "../theme/config";
+
+const TagLink = styled(TextLink)`
+  font-size: 0.8rem;
+
+  background: ${color.secondary};
+
+  padding: 0.5em 1em;
+
+  &:hover {
+    background: ${color.accent};
+    color: ${color.primary};
+  }
+`;
+
+export default TagLink;

--- a/src/content/posts/2020-04-16-site-welcome.md
+++ b/src/content/posts/2020-04-16-site-welcome.md
@@ -3,6 +3,7 @@ path: "/blog/site-welcome"
 date: "2020-04-16"
 author: "Ben Silverman"
 title: "Welcome to our new website!"
+tags: ["post"]
 ---
 
 Hi all!

--- a/src/content/posts/2020-10-02-freshers-welcome-2020.md
+++ b/src/content/posts/2020-10-02-freshers-welcome-2020.md
@@ -3,6 +3,7 @@ path: "/blog/freshers-welcome-2020"
 date: "2020-10-02"
 author: "Tom O'Neill"
 title: "A welcome to the 2020 freshers!"
+tags: ["post"]
 ---
 
 Hello!

--- a/src/content/posts/2021-10-13-giag2021-web1-writeup/index.md
+++ b/src/content/posts/2021-10-13-giag2021-web1-writeup/index.md
@@ -3,6 +3,7 @@ path: "/blog/giag2021-web1-challenge-guide"
 date: "2021-10-13"
 author: "Ben Silverman"
 title: "GIAG 2021 Web 1 Challenge Guide"
+tags: ["walkthrough"]
 ---
 
 This guide is for the Web 1 challenge of our 2021 _Give It A Go_ workshop!

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 // Components
 import Layout from "@components/Layout";
 import PostLink from "@components/PostLink";
+import TextLink from "@components/TextLink";
 
 const BlogIndexPage = ({
   data: {
@@ -19,6 +20,7 @@ const BlogIndexPage = ({
         <div className="row my-5">
           <div className="col">
             <h1>Blog</h1>
+            <TextLink to="/tags">View Tags</TextLink>
             {Posts}
           </div>
         </div>

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -20,7 +20,7 @@ const BlogIndexPage = ({
         <div className="row my-5">
           <div className="col">
             <h1>Blog</h1>
-            <TextLink to="/tags">View Tags</TextLink>
+            <TextLink to="/tags">View all tags</TextLink>
             {Posts}
           </div>
         </div>

--- a/src/pages/newsletter.js
+++ b/src/pages/newsletter.js
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import Layout from "../components/Layout";
-import { RegistrationForm } from "../components/RegistrationForm";
+import Layout from "@components/Layout";
+import { RegistrationForm } from "@components/RegistrationForm";
 
 import { color } from "../theme/config";
 
@@ -35,11 +35,11 @@ const Newsletter = () => {
               <DetailSummary>Disclaimer</DetailSummary>
               By completing this form you are giving consent for the student group to hold this data
               on file for the purposes of administering activities. This information is processed on
-              a contract basis and the information will be retained on file. The
-              society has agreed to adhere to YUSU’s Data Protection & Information Security, for
-              further information on how YUSU use student data and what your rights are can be found
-              within the YUSU Student Data Privacy Statement on our website. If you have any queries
-              please contact <b>dataprotection@yusu.org</b>.
+              a contract basis and the information will be retained on file. The society has agreed
+              to adhere to YUSU’s Data Protection & Information Security, for further information on
+              how YUSU use student data and what your rights are can be found within the YUSU
+              Student Data Privacy Statement on our website. If you have any queries please contact{" "}
+              <b>dataprotection@yusu.org</b>.
             </Details>
           </div>
         </div>

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,36 +1,33 @@
 import React from "react";
 import PropTypes from "prop-types";
-
-// Utilities
+import { Link, graphql } from "gatsby";
 import kebabCase from "lodash/kebabCase";
 
-// Components
-import { Helmet } from "react-helmet";
-import { Link, graphql } from "gatsby";
+import Layout from "../components/Layout";
 
 const TagsPage = ({
   data: {
     allMarkdownRemark: { group },
-    site: {
-      siteMetadata: { title },
-    },
   },
 }) => (
-  <div>
-    <Helmet title={title} />
-    <div>
-      <h1>Tags</h1>
-      <ul>
-        {group.map((tag) => (
-          <li key={tag.fieldValue}>
-            <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
-              {tag.fieldValue} ({tag.totalCount})
-            </Link>
-          </li>
-        ))}
-      </ul>
+  <Layout title="Tags">
+    <div className="container">
+      <div className="row my-5" id="tags">
+        <div className="col">
+          <h1>Tags</h1>
+          <ul>
+            {group.map((tag) => (
+              <li key={tag.fieldValue}>
+                <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
+                  {tag.fieldValue} ({tag.totalCount})
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
-  </div>
+  </Layout>
 );
 
 // This is vile I might just remove this.

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Link, graphql } from "gatsby";
 import kebabCase from "lodash/kebabCase";
 
-import Layout from "../components/Layout";
+import Layout from "@components/Layout";
 
 const TagsPage = ({
   data: {
@@ -53,11 +53,6 @@ export default TagsPage;
 
 export const pageQuery = graphql`
   query {
-    site {
-      siteMetadata {
-        title
-      }
-    }
     allMarkdownRemark(limit: 2000) {
       group(field: frontmatter___tags) {
         fieldValue

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,9 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link, graphql } from "gatsby";
+import { graphql } from "gatsby";
 import kebabCase from "lodash/kebabCase";
+import styled from "styled-components";
 
 import Layout from "@components/Layout";
+import TagLink from "@components/Tag";
+
+const TagCloud = styled.div`
+  display: flex;
+  gap: 0.5em;
+
+  flex-wrap: wrap;
+`;
 
 const TagsPage = ({
   data: {
@@ -16,15 +25,13 @@ const TagsPage = ({
         <div className="col">
           <h1>Tags</h1>
           <p>Explore all of our posts through their tags.</p>
-          <ul>
+          <TagCloud>
             {group.map((tag) => (
-              <li key={tag.fieldValue}>
-                <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
-                  {tag.fieldValue} ({tag.totalCount})
-                </Link>
-              </li>
+              <TagLink key={tag.fieldValue} to={`/tags/${kebabCase(tag.fieldValue)}/`}>
+                {tag.fieldValue} ({tag.totalCount})
+              </TagLink>
             ))}
-          </ul>
+          </TagCloud>
         </div>
       </div>
     </div>

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -15,6 +15,7 @@ const TagsPage = ({
       <div className="row my-5" id="tags">
         <div className="col">
           <h1>Tags</h1>
+          <p>Explore all of our posts through their tags.</p>
           <ul>
             {group.map((tag) => (
               <li key={tag.fieldValue}>

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,0 +1,71 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// Utilities
+import kebabCase from "lodash/kebabCase";
+
+// Components
+import { Helmet } from "react-helmet";
+import { Link, graphql } from "gatsby";
+
+const TagsPage = ({
+  data: {
+    allMarkdownRemark: { group },
+    site: {
+      siteMetadata: { title },
+    },
+  },
+}) => (
+  <div>
+    <Helmet title={title} />
+    <div>
+      <h1>Tags</h1>
+      <ul>
+        {group.map((tag) => (
+          <li key={tag.fieldValue}>
+            <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
+              {tag.fieldValue} ({tag.totalCount})
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </div>
+);
+
+// This is vile I might just remove this.
+TagsPage.propTypes = {
+  data: PropTypes.shape({
+    allMarkdownRemark: PropTypes.shape({
+      group: PropTypes.arrayOf(
+        PropTypes.shape({
+          fieldValue: PropTypes.string.isRequired,
+          totalCount: PropTypes.number.isRequired,
+        }).isRequired,
+      ),
+    }),
+    site: PropTypes.shape({
+      siteMetadata: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+      }),
+    }),
+  }),
+};
+
+export default TagsPage;
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    allMarkdownRemark(limit: 2000) {
+      group(field: frontmatter___tags) {
+        fieldValue
+        totalCount
+      }
+    }
+  }
+`;

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import Button from "@components/Button";
 import Layout from "@components/Layout";
-import TextLink from "@components/TextLink";
+import TagLink from "@components/Tag";
 
 import { color } from "@theme/config";
 
@@ -40,19 +40,6 @@ const TagHolder = styled.div`
   margin-bottom: 1em;
 
   width: fit-content;
-`;
-
-const TagLink = styled(TextLink)`
-  font-size: 0.8rem;
-
-  background: ${color.secondary};
-
-  padding: 0.5em 1em;
-
-  &:hover {
-    background: ${color.accent};
-    color: ${color.primary};
-  }
 `;
 
 export default function Template({

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -35,14 +35,24 @@ const BackButton = styled(Button)`
 
 const TagHolder = styled.div`
   display: flex;
-  gap: 1em;
+  gap: 0.5em;
 
-  margin: 1em 0;
-  padding: 1em;
+  margin-bottom: 1em;
+
+  width: fit-content;
+`;
+
+const TagLink = styled(TextLink)`
+  font-size: 0.8rem;
 
   background: ${color.secondary};
 
-  width: fit-content;
+  padding: 0.5em 1em;
+
+  &:hover {
+    background: ${color.accent};
+    color: ${color.primary};
+  }
 `;
 
 export default function Template({
@@ -59,19 +69,18 @@ export default function Template({
               Back
             </BackButton>
             <Title>{frontmatter.title}</Title>
-            <Detail>
-              <span>{frontmatter.author}</span> - <Date>{frontmatter.date}</Date>
-            </Detail>
             {frontmatter.tags.length > 0 ? (
               <TagHolder>
-                Tags:
                 {frontmatter.tags.map((tag, i) => (
-                  <TextLink key={i} to={`/tags/${tag}`}>
+                  <TagLink key={i} to={`/tags/${tag}`}>
                     {tag}
-                  </TextLink>
+                  </TagLink>
                 ))}
               </TagHolder>
             ) : null}
+            <Detail>
+              <span>{frontmatter.author}</span> - <Date>{frontmatter.date}</Date>
+            </Detail>
             <Content dangerouslySetInnerHTML={{ __html: html }} />
           </div>
         </div>

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 import Button from "@components/Button";
 import Layout from "@components/Layout";
+import TextLink from "@components/TextLink";
 
 import { color } from "@theme/config";
 
@@ -32,6 +33,18 @@ const BackButton = styled(Button)`
   padding: 0.25em 0.5em;
 `;
 
+const TagHolder = styled.div`
+  display: flex;
+  gap: 1em;
+
+  margin: 1em 0;
+  padding: 1em;
+
+  background: ${color.secondary};
+
+  width: fit-content;
+`;
+
 export default function Template({
   data, // this prop will be injected by the GraphQL query below.
 }) {
@@ -49,6 +62,14 @@ export default function Template({
             <Detail>
               <span>{frontmatter.author}</span> - <Date>{frontmatter.date}</Date>
             </Detail>
+            <TagHolder>
+              Tags:
+              {frontmatter.tags.map((tag, i) => (
+                <TextLink key={i} to={`/tags/${tag}`}>
+                  {tag}
+                </TextLink>
+              ))}
+            </TagHolder>
             <Content dangerouslySetInnerHTML={{ __html: html }} />
           </div>
         </div>
@@ -70,6 +91,7 @@ export const pageQuery = graphql`
         path
         title
         author
+        tags
       }
     }
   }

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -62,14 +62,16 @@ export default function Template({
             <Detail>
               <span>{frontmatter.author}</span> - <Date>{frontmatter.date}</Date>
             </Detail>
-            <TagHolder>
-              Tags:
-              {frontmatter.tags.map((tag, i) => (
-                <TextLink key={i} to={`/tags/${tag}`}>
-                  {tag}
-                </TextLink>
-              ))}
-            </TagHolder>
+            {frontmatter.tags.length > 0 ? (
+              <TagHolder>
+                Tags:
+                {frontmatter.tags.map((tag, i) => (
+                  <TextLink key={i} to={`/tags/${tag}`}>
+                    {tag}
+                  </TextLink>
+                ))}
+              </TagHolder>
+            ) : null}
             <Content dangerouslySetInnerHTML={{ __html: html }} />
           </div>
         </div>

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -1,0 +1,79 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { graphql } from "gatsby";
+
+import TextLink from "../components/TextLink";
+
+const TagTemplate = ({ pageContext, data }) => {
+  const { tag } = pageContext;
+  const { edges, totalCount } = data.allMarkdownRemark;
+  const tagHeader = `${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${tag}"`;
+
+  return (
+    <div>
+      <h1>{tagHeader}</h1>
+      <ul>
+        {edges.map(({ node }) => {
+          const { title, path } = node.frontmatter;
+          return (
+            <li key={path}>
+              <TextLink to={path}>{title}</TextLink>
+            </li>
+          );
+        })}
+      </ul>
+      {/*
+              This links to a page that does not yet exist.
+              You'll come back to it!
+            */}
+      <TextLink to="/tags">All tags</TextLink>
+    </div>
+  );
+};
+
+export default TagTemplate;
+
+// I HATE this...
+// Maybe should move the site to TypeScript at some point? :P
+TagTemplate.propTypes = {
+  pageContext: PropTypes.shape({
+    tag: PropTypes.string.isRequired,
+  }),
+  data: PropTypes.shape({
+    allMarkdownRemark: PropTypes.shape({
+      totalCount: PropTypes.number.isRequired,
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            frontmatter: PropTypes.shape({
+              title: PropTypes.string.isRequired,
+            }),
+            fields: PropTypes.shape({
+              slug: PropTypes.string.isRequired,
+            }),
+          }),
+        }).isRequired,
+      ),
+    }),
+  }),
+};
+
+export const pageQuery = graphql`
+  query ($tag: String) {
+    allMarkdownRemark(
+      limit: 2000
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { tags: { in: [$tag] } } }
+    ) {
+      totalCount
+      edges {
+        node {
+          frontmatter {
+            path
+            title
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -17,12 +17,12 @@ const TagTemplate = ({ pageContext, data }) => {
         <div className="row my-5" id="tags">
           <div className="col">
             <h1>{tagHeader}</h1>
+            <TextLink to="/tags">View all tags</TextLink>
             {edges.map(({ node }) => {
               const { path } = node.frontmatter;
 
               return <PostLink key={path} post={node} />;
             })}
-            <TextLink to="/tags">All tags</TextLink>
           </div>
         </div>
       </div>

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -2,7 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { graphql } from "gatsby";
 
-import TextLink from "../components/TextLink";
+import TextLink from "@components/TextLink";
+import Layout from "@components/Layout";
+import PostLink from "@components/PostLink";
 
 const TagTemplate = ({ pageContext, data }) => {
   const { tag } = pageContext;
@@ -10,24 +12,21 @@ const TagTemplate = ({ pageContext, data }) => {
   const tagHeader = `${totalCount} post${totalCount === 1 ? "" : "s"} tagged with "${tag}"`;
 
   return (
-    <div>
-      <h1>{tagHeader}</h1>
-      <ul>
-        {edges.map(({ node }) => {
-          const { title, path } = node.frontmatter;
-          return (
-            <li key={path}>
-              <TextLink to={path}>{title}</TextLink>
-            </li>
-          );
-        })}
-      </ul>
-      {/*
-              This links to a page that does not yet exist.
-              You'll come back to it!
-            */}
-      <TextLink to="/tags">All tags</TextLink>
-    </div>
+    <Layout title={`Posts tagged "${tag}"`}>
+      <div className="container">
+        <div className="row my-5" id="tags">
+          <div className="col">
+            <h1>{tagHeader}</h1>
+            {edges.map(({ node }) => {
+              const { path } = node.frontmatter;
+
+              return <PostLink key={path} post={node} />;
+            })}
+            <TextLink to="/tags">All tags</TextLink>
+          </div>
+        </div>
+      </div>
+    </Layout>
   );
 };
 
@@ -68,9 +67,12 @@ export const pageQuery = graphql`
       totalCount
       edges {
         node {
+          excerpt(pruneLength: 350)
           frontmatter {
+            date(formatString: "MMMM DD, YYYY")
             path
             title
+            author
           }
         }
       }


### PR DESCRIPTION
(closes #47)

Tags can be added to a post by including them as part of the post's frontmatter.

```md
---
path: "/blog/tagged-post-example"
date: "2021-11-07"
author: "Ben Silverman"
title: "This post shows off the new tag feature!"
tags: ["post", "example"]
---
```

Tags are rendered in a section at the top of each blog post, as a series of clickable links.

![image](https://user-images.githubusercontent.com/21127383/140656957-8850c03a-a03e-4b72-a0cf-31188a1d9b18.png)

Clicking on a tag here takes the user to a page containing all of the posts with that tag, sorted by most recent.

![image](https://user-images.githubusercontent.com/21127383/140656976-14e4c20a-af57-4b3f-9ea4-a65d55575929.png)

Clicking on *View all tags* takes the user to a page display all the possible tags they can view, as well as how many posts use the tag.

![image](https://user-images.githubusercontent.com/21127383/140657004-6f6a86c5-36b7-4aac-9285-39d8fe860b42.png)
